### PR TITLE
Split only at first equal sign per line

### DIFF
--- a/tasks/properties_reader.js
+++ b/tasks/properties_reader.js
@@ -21,7 +21,7 @@ function convertPropsToJson(text) {
                 val;
             line = line.trim();
             if (line && line.indexOf("#") !== 0 && line.indexOf("!") !== 0) {
-                props = line.split("=");
+                props = line.split(/=(.+)?/);
                 name = props[0].trim();
                 val = props[1].trim();
                 configObject[name] = _convertStringIfTrue(val);

--- a/test/files/default.properties
+++ b/test/files/default.properties
@@ -4,3 +4,4 @@ string=hello world
 !comment here
 i.have.dots=a.b.c
     spaces = are fine
+eqsign=<script src='bla.js'></script>

--- a/test/properties_reader_test.js
+++ b/test/properties_reader_test.js
@@ -33,7 +33,8 @@ exports.properties_reader = {
       number: "1234",
       string: "hello world",
       "i.have.dots": "a.b.c",
-      spaces: "are fine"
+      spaces: "are fine",
+      eqsign: "<script src='bla.js'></script>"
     };
 
     test.deepEqual(grunt.config.get("defaultTemplateTest"), { test: true, string: "hello world"});


### PR DESCRIPTION
Changed the call to split to use greedy regex in order to split only on first occurrence of equal sign.
Added a test to demonstrate my use case.
