### PR TITLE
Read and merge properties from multiple properties files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 npm-debug.log
 tmp
+*.swp

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,11 +30,13 @@ module.exports = function(grunt) {
 
     // Configuration to be run (and then tested).
     properties: {
-      default: 'test/files/default.properties'
+      single_file: 'test/files/default.properties',
+      multi_file: [ 'test/files/default.properties', 'test/files/overrides.properties' ],
+      optional_file: [ 'test/files/default.properties', 'test/files/not_found.properties' ]
     },
     defaultTemplateTest: {
-      test: '<%= default.test %>',
-      string: '<%= default.string %>'
+      test: '<%= single_file.test %>',
+      string: '<%= single_file.string %>'
     },
     // Unit tests.
     nodeunit: {

--- a/README.md
+++ b/README.md
@@ -65,6 +65,44 @@ grunt.registerTask('cleanDeploy', ['properties', 'clean:deployDir'])
 
 Running `grunt cleanDeploy` from the command line will delete the directory.
 
+#### Multiple Files
+In this example, multiple properties files are read in the order specified.  Values from subsequent files are merged with those from the proceeding.  Therefore, values from proceeding files will overwrite those from the preceeding files.  Consider the following properties files:
+
+```default.properties
+deployDir=C:\server\deployment
+```
+```overrides.properties
+deployDir=/opt/server
+debug=true
+```
+
+```js
+grunt.initConfig({
+  properties: {
+    app: [ 'default.properties', 'overrides.properties' ]
+  },
+  clean: {
+    deployDir: '<%= app.deployDir %>'
+  }
+})
+
+grunt.loadNpmTasks('grunt-contrib-clean');
+grunt.loadNpmTasks('grunt-properties-reader');
+
+grunt.registerTask('cleanDeploy', ['properties', 'clean:deployDir'])
+```
+
+When executed, the app variable will contain the following values:
+
+```js
+{
+  deployDir=/opt/server
+  debug=true
+}
+```
+
+Finally, when using multiple files, the first file in the list must be present.  All subsequent files are optional, and will not cause the task to fail if they are not present.
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/tasks/properties_reader.js
+++ b/tasks/properties_reader.js
@@ -9,29 +9,6 @@
 'use strict';
 
 /**
- * Convert properties string into a json object
- * Only supports boolean and string types
- */
-function convertPropsToJson(text) {
-    var configObject = {};
-    if (text && text.length) {
-        text.split(/\r?\n/g).forEach(function (line) {
-            var props,
-                name,
-                val;
-            line = line.trim();
-            if (line && line.indexOf("#") !== 0 && line.indexOf("!") !== 0) {
-                props = line.split(/=(.+)?/);
-                name = props[0].trim();
-                val = props[1].trim();
-                configObject[name] = _convertStringIfTrue(val);
-            }
-        });
-    }
-    return configObject;
-};
-
-/**
  * If a string is "true" "TRUE", or "  TrUE" convert to boolean type else
  * leave as is
  */
@@ -44,32 +21,98 @@ function _convertStringIfTrue(original) {
     return original;
 }
 
+/**
+ * Convert properties string into a json object
+ * Only supports boolean and string types
+ */
+function convertPropsToJson(text) {
+    var configObject = {};
+    if (text && text.length) {
+        text.split(/\r?\n/g).forEach(function (line) {
+            var props,
+                name,
+                val;
+            line = line.trim();
+            if (line && line.indexOf("#") !== 0 && line.indexOf("!") !== 0) {
+                props = line.split(/\=(.+)?/);
+                name = props[0].trim();
+                val = props[1].trim();
+                configObject[name] = _convertStringIfTrue(val);
+            }
+        });
+    }
+    return configObject;
+}
+
+function merge(target, source) {
+
+  if (!source) {
+    return target;
+  }
+
+  for (var key in source) {
+    target[key] = source[key];
+  }
+
+  return target;
+
+}
+
+function convertToArray(value, grunt) {
+
+    if (!value) {
+        return [];
+    }
+
+    if (value instanceof Array) {
+        return value;
+    }
+
+    return [ value ];
+
+}
+
 module.exports = function(grunt) {
 
   // Please see the Grunt documentation for more information regarding task
   // creation: http://gruntjs.com/creating-tasks
 
-  grunt.registerMultiTask('properties', 'Your task description goes here.', function() {
-    // Merge task-specific and/or target-specific options with these defaults.
-    var filename = this.data,
-      file = (function (fileReadOptions) {
-        return grunt.file.exists(filename) && grunt.file.read(filename, fileReadOptions);
-      }(this.options)),
-      parsed;
+  grunt.registerMultiTask('properties', 
+    'Reads values from one or more Java style properties into the specified variable', 
+    function() {
 
-    if (!file) {
-        grunt.log.error("Could not read file: " + filename);
-        return false;
-    }
+        var readFile = function(filename, readOptions) {
+            return grunt.file.exists(filename) && grunt.file.read(filename, readOptions);
+        };
 
-    parsed = convertPropsToJson(file);
+        // Merge task-specific and/or target-specific options with these defaults.
+        if (grunt.config.get(this.target)) {
+            grunt.log.error("Conflict - property, " + this.target + ", already exists in grunt config");
+            return false;
+        }
 
-    if (grunt.config.get(this.target)) {
-        grunt.log.error("Conflict - property already exists in grunt config");
-        return false;
-    }
+        var filenames = convertToArray(this.data);
 
-    grunt.config.set(this.target, parsed);
-  });
+        var parsed = {};
+        for (var i=0; i < filenames.length; i++) {
+
+          var filename = filenames[i];
+          var file = readFile(filename, this.options);
+
+          // Only require the first file ...
+          if (!file && i === 0) {
+              grunt.log.error("Could not read required properties file: " + filename);
+              return false;
+          } else if (!file) {
+              grunt.log.warn("Could not read optional properties file: " + filename);
+          }
+
+          parsed = merge(parsed, convertPropsToJson(file));
+
+       }
+
+       grunt.config.set(this.target, parsed);
+
+    });
 
 };

--- a/test/files/overrides.properties
+++ b/test/files/overrides.properties
@@ -1,0 +1,8 @@
+test=true
+number=1234
+string=hello world 2
+!comment here
+i.have.dots=a.b.c
+    spaces = are fine
+eqsign=<script src='bla.js'></script>
+override=foobar

--- a/test/properties_reader_test.js
+++ b/test/properties_reader_test.js
@@ -22,7 +22,7 @@ var grunt = require('grunt');
     test.ifError(value)
 */
 
-exports.properties_reader = {
+exports.single_file_properties_reader = {
   setUp: function(done) {
     done();
   },
@@ -38,7 +38,7 @@ exports.properties_reader = {
     };
 
     test.deepEqual(grunt.config.get("defaultTemplateTest"), { test: true, string: "hello world"});
-    test.deepEqual(grunt.config.get("default"), expected);
+    test.deepEqual(grunt.config.get("single_file"), expected);
 
     test.done();
   },
@@ -50,3 +50,54 @@ exports.properties_reader = {
     test.done();
   },
 };
+
+exports.multi_file_properties_reader = {
+  setUp: function(done) {
+    done();
+  },
+  default_options: function(test) {
+    test.expect(1);
+    var expected = {
+      test: true,
+      number: "1234",
+      string: "hello world 2",
+      "i.have.dots": "a.b.c",
+      spaces: "are fine",
+      eqsign: "<script src='bla.js'></script>",
+      override: "foobar"
+    };
+
+    test.deepEqual(grunt.config.get("multi_file"), expected);
+
+    test.done();
+  },
+  custom_options: function(test) {
+    test.done();
+  },
+};
+
+exports.optional_file_properties_reader = {
+  setUp: function(done) {
+    done();
+  },
+  default_options: function(test) {
+    test.expect(1);
+    var expected = {
+      test: true,
+      number: "1234",
+      string: "hello world",
+      "i.have.dots": "a.b.c",
+      spaces: "are fine",
+      eqsign: "<script src='bla.js'></script>"
+    };
+
+    test.deepEqual(grunt.config.get("optional_file"), expected);
+
+    test.done();
+  },
+  custom_options: function(test) {
+    test.done();
+  },
+};
+
+


### PR DESCRIPTION
- Reads and merges properties from multiple files.  The first file provided is required, and all subsequent files are treated as optional where property values from subsequent files override those in preceding files.
- Adds unit tests for the multiple file behavior
- Adds description of multiple file behavior to README.md
- Fixes a pre-existing jshint warnings
- Adds vim swap files to the .gitignore
