### PR TITLE
Add support for multi-line values

### DIFF
--- a/tasks/properties_reader.js
+++ b/tasks/properties_reader.js
@@ -28,6 +28,8 @@ function _convertStringIfTrue(original) {
 function convertPropsToJson(text) {
     var configObject = {};
     if (text && text.length) {
+        // handle multi-line values terminated with a backslash
+        text = text.replace(/\\\r?\n\s*/g, '');
         text.split(/\r?\n/g).forEach(function (line) {
             var props,
                 name,

--- a/test/files/default.properties
+++ b/test/files/default.properties
@@ -6,3 +6,8 @@ i.have.dots=a.b.c
     spaces = are fine
 eqsign=<script src='bla.js'></script>
 empty=
+multilineval=line1, \
+line2
+multilineval2=first \
+              second \
+              third

--- a/test/properties_reader_test.js
+++ b/test/properties_reader_test.js
@@ -35,7 +35,9 @@ exports.single_file_properties_reader = {
       "i.have.dots": "a.b.c",
       spaces: "are fine",
       eqsign: "<script src='bla.js'></script>",
-      empty: undefined
+      empty: undefined,
+      multilineval: 'line1, line2',
+      multilineval2: 'first second third'
     };
 
     test.deepEqual(grunt.config.get("defaultTemplateTest"), { test: true, string: "hello world"});
@@ -66,7 +68,9 @@ exports.multi_file_properties_reader = {
       spaces: "are fine",
       eqsign: "<script src='bla.js'></script>",
       override: "foobar",
-      empty: undefined
+      empty: undefined,
+      multilineval: 'line1, line2',
+      multilineval2: 'first second third'
     };
 
     test.deepEqual(grunt.config.get("multi_file"), expected);
@@ -91,7 +95,9 @@ exports.optional_file_properties_reader = {
       "i.have.dots": "a.b.c",
       spaces: "are fine",
       eqsign: "<script src='bla.js'></script>",
-      empty: undefined
+      empty: undefined,
+      multilineval: 'line1, line2',
+      multilineval2: 'first second third'
     };
 
     test.deepEqual(grunt.config.get("optional_file"), expected);


### PR DESCRIPTION
Handles lines terminated with a backslash, which indicates the value continues onto the next line.

Example:

```
countries=United States, \
          France, \
          Brazil
```

The value is translated into "United States, France, Brazil"
